### PR TITLE
feat(p-abort)!: remove deprecated defer method

### DIFF
--- a/.changeset/crazy-masks-follow.md
+++ b/.changeset/crazy-masks-follow.md
@@ -1,0 +1,5 @@
+---
+"p-abort": minor
+---
+
+remove defer

--- a/packages/p-abort/README.md
+++ b/packages/p-abort/README.md
@@ -143,9 +143,6 @@ Wraps a function to make it abort-aware. The wrapped function will check for abo
 #### `$.cleanup(fn)`
 Registers a cleanup function to be called when the operation completes or is aborted. Cleanup functions are executed in reverse order of registration (LIFO). Useful for resource cleanup.
 
-#### `$.defer(fn)` (deprecated)
-Alias for `$.cleanup()`. Use `$.cleanup()` instead.
-
 ## Error Handling
 
 When an operation is aborted, any in-progress steps are cancelled and the promise resolves to `{ ok: false }`. Other errors are propagated normally.

--- a/packages/p-abort/src/index.test.ts
+++ b/packages/p-abort/src/index.test.ts
@@ -201,19 +201,6 @@ describe('abortable', () => {
     const result = await operation([1, 2, 3]);
     expect(result).toEqual({ ok: true, data: [2, 4, 6] });
   });
-
-  it('should maintain backward compatibility with defer', async () => {
-    const cleanupSpy = vi.fn();
-
-    const operation = abortable(($) => async () => {
-      $.defer(cleanupSpy); // Using deprecated defer method
-      return 'success';
-    });
-
-    const result = await operation();
-    expect(result).toEqual({ ok: true, data: 'success' });
-    expect(cleanupSpy).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe('AbortedError', () => {

--- a/packages/p-abort/src/index.ts
+++ b/packages/p-abort/src/index.ts
@@ -99,9 +99,6 @@ export function abortable<TParams extends readonly unknown[], TReturn>(
       cleanupFunctions.push(fn);
     };
 
-    // Backward compatibility - keep defer as alias for cleanup
-    $.defer = $.cleanup;
-
     const runCleanup = () => {
       for (const fn of cleanupFunctions.reverse()) {
         try {
@@ -161,11 +158,6 @@ interface AbortableUtility {
    * @param fn - The cleanup function to register
    */
   cleanup: (fn: () => void) => void;
-
-  /**
-   * @deprecated Use `cleanup` instead. Registers a cleanup function.
-   */
-  defer: (fn: () => void) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
Removes the deprecated `defer` method from the p-abort package.

## Changes
- **BREAKING CHANGE**: Removed `$.defer()` method (deprecated alias for `$.cleanup()`)
- Updated README.md to remove deprecated method documentation
- Removed backward compatibility test for `defer` method

## Migration Guide
Replace any usage of `$.defer(fn)` with `$.cleanup(fn)`. The `cleanup` method provides identical functionality.

## Checklist
- [x] Code changes implemented
- [x] Tests updated
- [x] Documentation updated
- [x] Changeset added
