### PR TITLE
chore: replace deprecated ubi backend with registry d2 in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 node = "24.12.0"
 pnpm = "10.22.0"
-"ubi:terrastruct/d2" = "latest"
+d2 = "0.7.1"


### PR DESCRIPTION
## What

Replace the deprecated `ubi:terrastruct/d2` backend in `mise.toml` with the mise registry short name `d2`, pinned to `0.7.1`.

## Why

The `ubi` backend is deprecated. The registry short name resolves via the aqua backend (checksum-verified) and is the recommended way to reference `d2`.

## Verification

`mise install d2` installs `d2@0.7.1` and `mise which d2` resolves the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)