### PR TITLE
ci: bump pinned mise version to 2026.6.5

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: jdx/mise-action@v3
       with:
-        version: 2025.12.12
+        version: 2026.6.5
         cache: true
     - run: pnpm install
       shell: bash


### PR DESCRIPTION
## What

Bumps the mise version pinned in `.github/actions/setup/action.yml` from `2025.12.12` to `2026.6.5`.

## Why

CI fails with:

```
mise ERROR d2 not found in mise tool registry
```

The `d2` short name resolves via mise's bundled tool registry, which ships with the mise binary. `2025.12.12` predates the `d2` registry entry; `2026.6.5` includes it (verified locally with `mise registry d2`).

This unblocks #40 (which switches `mise.toml` to the `d2` registry short name) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)