### PR TITLE
fix(soonloh): diagnose config/router-root failures instead of crashing

### DIFF
--- a/.changeset/soft-config-hardening.md
+++ b/.changeset/soft-config-hardening.md
@@ -1,0 +1,5 @@
+---
+'soonloh': patch
+---
+
+Diagnose missing config file, malformed config, and missing router root with readable errors instead of crashing the dev server

--- a/packages/soonloh/src/core/config.ts
+++ b/packages/soonloh/src/core/config.ts
@@ -18,3 +18,36 @@ export interface CodeGenerator<TSegment> {
 
 export const config = <TSegment>(value: Config<TSegment>): Config<TSegment> =>
   value;
+
+/**
+ * Checks that a value loaded at runtime (config file default export or inline
+ * config) actually has the shape of a {@link Config}, so a malformed config
+ * surfaces as one readable diagnostic instead of a TypeError mid-codegen.
+ */
+export function validateConfig<TSegment = unknown>(
+  value: unknown,
+  source: string,
+): Config<TSegment> {
+  const problems: string[] = [];
+  if (typeof value !== 'object' || value == null) {
+    problems.push(
+      'the default export is not a config object — `export default config({ ... })`',
+    );
+  } else {
+    const v = value as Partial<Config<TSegment>>;
+    if (typeof v.routerRoot !== 'string')
+      problems.push('`routerRoot` must be a string path');
+    if (typeof v.parser !== 'function')
+      problems.push('`parser` must be a function');
+    if (!Array.isArray(v.generators))
+      problems.push('`generators` must be an array');
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `invalid config (${source}):\n${problems
+        .map((p) => `  - ${p}`)
+        .join('\n')}`,
+    );
+  }
+  return value as Config<TSegment>;
+}

--- a/packages/soonloh/src/core/plugin.test.ts
+++ b/packages/soonloh/src/core/plugin.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { SoonlohPlugin } from './plugin.js';
+import { config as defineConfig, Config } from './config.js';
+
+describe('SoonlohPlugin hardening', () => {
+  const cwd = process.cwd();
+  afterEach(() => {
+    process.chdir(cwd);
+    vi.restoreAllMocks();
+  });
+
+  it('missing soonloh.config.ts is diagnosed without rejecting (#8)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'soonloh-hardening-'));
+    try {
+      process.chdir(dir);
+      const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const plugin = new SoonlohPlugin({});
+      await expect(plugin.loadConfig()).resolves.toBeUndefined();
+      await expect(plugin.generate()).resolves.toMatchObject({ ok: true });
+      expect(errors.mock.calls.flat().join('\n')).toContain(
+        'config file not found',
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('config missing properties is diagnosed without throwing (#9)', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const plugin = new SoonlohPlugin({
+      config: { routerRoot: 'src/app/' } as Config,
+    });
+    await expect(plugin.loadConfig()).resolves.toBeUndefined();
+    await expect(plugin.generate()).resolves.toMatchObject({ ok: true });
+    const diagnostic = errors.mock.calls.flat().join('\n');
+    expect(diagnostic).toContain('`parser` must be a function');
+    expect(diagnostic).toContain('`generators` must be an array');
+  });
+
+  it('missing router root directory is diagnosed without rejecting (#10)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'soonloh-hardening-'));
+    try {
+      process.chdir(dir);
+      const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const plugin = new SoonlohPlugin({
+        config: defineConfig({
+          routerRoot: 'does-not-exist/',
+          parser: () => null,
+          generators: [],
+        }),
+      });
+      await plugin.loadConfig();
+      await expect(plugin.generate()).resolves.toMatchObject({ ok: true });
+      expect(errors.mock.calls.flat().join('\n')).toContain(
+        'router root not found',
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/soonloh/src/core/plugin.ts
+++ b/packages/soonloh/src/core/plugin.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { stat, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { setTimeout } from 'node:timers/promises';
-import { Config } from './config.js';
+import { Config, validateConfig } from './config.js';
 import { AbortableTask, AbortedError, runAbortable } from 'p-abort';
 import { createSoonlohRuntime } from '../rt.js';
 
@@ -52,40 +52,58 @@ export class SoonlohPlugin {
     if (typeof file !== 'string') {
       // Inline config: nothing to import, just resolve the router root from it.
       if (this.#config) {
-        const config = await this.#config;
-        this.routerRoot = path.join(this.#root, config.routerRoot);
-        this.hasConfigResolved = true;
+        try {
+          const config = validateConfig(await this.#config, 'inline config');
+          this.routerRoot = path.join(this.#root, config.routerRoot);
+          this.hasConfigResolved = true;
+        } catch (e) {
+          this.#config = null;
+          logError(e);
+        }
       }
       return;
     }
-    const href = pathToFileURL(file).href;
-    const mtime = (await stat(file)).mtime;
+    let mtime: Date;
+    try {
+      mtime = (await stat(file)).mtime;
+    } catch {
+      console.error(
+        `[soonloh] config file not found: ${file}\n` +
+          '          create it (or pass an inline config); codegen is paused until then',
+      );
+      return;
+    }
     if (isFileTs(file)) {
       if (!isDeno() && !isBun() && !isNodeSupportNativeTypeScript()) {
-        throw new Error('[soonloh] We cannot handle TypeScript file');
+        console.error(
+          '[soonloh] this runtime cannot import a TypeScript config file; use Node with native TS support (>= 22.6), Deno, or Bun',
+        );
+        return;
       }
     }
-    const promise = import(`${href}?t=${mtime}`).then(
-      (module) => module.default as Config,
+    const href = pathToFileURL(file).href;
+    const promise = import(`${href}?t=${mtime}`).then((module) =>
+      validateConfig(module.default, file),
     );
-    promise.then((config) => {
+    // Publish the in-flight promise on first load so an early generate() can
+    // await it instead of skipping the initial codegen.
+    const isFirstLoad = this.#config == null;
+    if (isFirstLoad) {
+      this.#config = promise;
+    }
+    try {
+      const config = await promise;
+      this.#config = Promise.resolve(config);
       this.hasConfigResolved = true;
       this.routerRoot = path.join(this.#root, config.routerRoot);
-      console.log('[soonloh] config loaded: ', this.routerRoot, {
-        cfg: config.routerRoot,
-      });
-    });
-    if (this.#config == null) {
-      this.#config = promise;
-    } else {
-      try {
-        this.#config = Promise.resolve(await promise);
-      } catch (e) {
-        console.error(
-          '[soonloh] failed to reload config, keep previous one...',
-        );
-        console.error(e);
+      console.log(`[soonloh] config loaded: ${file}`);
+    } catch (e) {
+      if (isFirstLoad) {
+        this.#config = null;
+      } else {
+        console.error('[soonloh] failed to reload config, keep previous one...');
       }
+      logError(e);
     }
   }
   // endregion
@@ -104,12 +122,27 @@ export class SoonlohPlugin {
       if (!this.hasConfigResolved) {
         console.log('[soonloh] waiting for the config to be loaded...');
       }
-      const routerRoot = this.routerRoot;
-      const config = await $(this.#config);
-      if (!routerRoot || !config) return;
+      // The in-flight promise may reject on a broken first load; the failure
+      // is already diagnosed in loadConfig, so just skip codegen here.
+      const config = await $(this.#config).catch(() => null);
+      if (!config) return;
 
       const rt = createSoonlohRuntime(config);
-      const routes = await rt.routes();
+      let routes;
+      try {
+        routes = await $(rt.routes());
+      } catch (e) {
+        if (e instanceof AbortedError) return;
+        if ((e as NodeJS.ErrnoException)?.code === 'ENOENT') {
+          console.error(
+            `[soonloh] router root not found: ${path.join(this.#root, config.routerRoot)}\n` +
+              '          create the directory or fix `routerRoot` in your config',
+          );
+        } else {
+          logError(e);
+        }
+        return;
+      }
       await $.all(
         config.generators.map(async (generator) => {
           try {
@@ -171,6 +204,9 @@ export class SoonlohPlugin {
   }
   // endregion
 }
+
+const logError = (e: unknown) =>
+  console.error(e instanceof Error ? `[soonloh] ${e.message}` : e);
 
 // ref: https://github.com/eslint/eslint/blob/60c3e2cf9256f3676b7934e26ff178aaf19c9e97/lib/config/config-loader.js#L85-L129
 const isFileTs = (file: string) => /^\.[mc]?ts$/.test(path.extname(file));


### PR DESCRIPTION
Hardens `SoonlohPlugin` so a broken setup pauses codegen with a readable `[soonloh]` diagnostic instead of an unhandled rejection that kills the dev server.

## What changed

- **Missing `soonloh.config.ts`** (#8): `loadConfig` catches the `stat` failure and prints where the file was expected; codegen stays paused until it exists.
- **Config missing properties** (#9): new `validateConfig()` checks `routerRoot`/`parser`/`generators` on both file and inline configs, reporting every missing property in one message instead of a `TypeError` mid-codegen.
- **Missing router root directory** (#10): `ENOENT` from route scanning is caught and reported with the resolved path and a fix hint.
- The unsupported-TypeScript-runtime check logs and pauses instead of throwing.
- A failed first config load no longer leaves a rejected promise behind for `generate()` to trip on (previously an unhandled rejection via the dangling `promise.then` chain).

## Tests

`plugin.test.ts` covers all three scenarios: each resolves cleanly (no rejection) and emits the expected diagnostic. Full suite: 51 tests pass, `tsc --noEmit` and `tsdown` build clean.

Closes #8
Closes #9
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)