### PR TITLE
fix(soonloh): add default export conditions so CJS metro configs can require('soonloh/metro')

### DIFF
--- a/.changeset/metro-cjs-exports.md
+++ b/.changeset/metro-cjs-exports.md
@@ -1,0 +1,5 @@
+---
+'soonloh': patch
+---
+
+Add a `default` condition to every `exports` subpath so `require('soonloh/metro')` resolves from CJS metro configs instead of throwing ERR_PACKAGE_PATH_NOT_EXPORTED

--- a/packages/soonloh/package.json
+++ b/packages/soonloh/package.json
@@ -29,27 +29,33 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./builtin-parsers": {
       "types": "./dist/builtin-parsers/index.d.ts",
-      "import": "./dist/builtin-parsers/index.js"
+      "import": "./dist/builtin-parsers/index.js",
+      "default": "./dist/builtin-parsers/index.js"
     },
     "./builtin-generators": {
       "types": "./dist/builtin-generators/index.d.ts",
-      "import": "./dist/builtin-generators/index.js"
+      "import": "./dist/builtin-generators/index.js",
+      "default": "./dist/builtin-generators/index.js"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",
-      "import": "./dist/vite.js"
+      "import": "./dist/vite.js",
+      "default": "./dist/vite.js"
     },
     "./metro": {
       "types": "./dist/metro.d.ts",
-      "import": "./dist/metro.js"
+      "import": "./dist/metro.js",
+      "default": "./dist/metro.js"
     },
     "./rt": {
       "types": "./dist/rt.d.ts",
-      "import": "./dist/rt.js"
+      "import": "./dist/rt.js",
+      "default": "./dist/rt.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

`require('soonloh/metro')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` because every `exports` subpath only declares `types` and `import` conditions. Metro configs are CJS by default, so the documented usage in the `withSoonloh` docstring (`require('soonloh/metro').default`) doesn't actually work — consumers need a dynamic-import workaround.

## Fix

Add a `default` condition to all six subpaths, pointing at the same ESM dist files. Node's require-of-ESM support (20.19+/22.12+) loads them fine from CJS — the module graph has no top-level await.

Verified by symlinking the package into a scratch `node_modules` and asserting `require('soonloh/metro').default` is a function and `require('soonloh/builtin-parsers')` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)